### PR TITLE
get contract addresses from subgraph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/client",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/client",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/client",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "description": "",
   "keywords": [],
   "main": "dist/lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/client",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "description": "",
   "keywords": [],
   "main": "dist/lib/index.js",

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -116,7 +116,6 @@ export class Arc {
         const accInfo = this.observedAccounts[address]
         if (accInfo) {
           // in theory it is possible that the client unsubscribed before reaching this callback
-
           accInfo.observer.next(new BN(currentBalance))
           accInfo.lastBalance = currentBalance
         }
@@ -309,32 +308,35 @@ export class Arc {
     if (!addresses) {
       throw new Error(`Cannot get contract: no contractAddress set`)
     }
+    if (!addresses[name]) {
+      throw new Error(`No contract named ${name} could be found in the provided contract addresses`)
+    }
     let contractClass
     let contract
     switch (name) {
       case 'AbsoluteVote':
         contractClass = require('@daostack/arc/build/contracts/AbsoluteVote.json')
-        contract = new this.web3.eth.Contract(contractClass.abi, addresses.base.AbsoluteVote, opts)
+        contract = new this.web3.eth.Contract(contractClass.abi, addresses.AbsoluteVote, opts)
         return contract
       case 'ContributionReward':
         contractClass = require('@daostack/arc/build/contracts/ContributionReward.json')
-        contract = new this.web3.eth.Contract(contractClass.abi, addresses.base.ContributionReward, opts)
+        contract = new this.web3.eth.Contract(contractClass.abi, addresses.ContributionReward, opts)
         return contract
       case 'GEN':
         contractClass = require('@daostack/arc/build/contracts/DAOToken.json')
-        contract = new this.web3.eth.Contract(contractClass.abi, addresses.base.GEN, opts)
+        contract = new this.web3.eth.Contract(contractClass.abi, addresses.GEN, opts)
         return contract
       case 'GenesisProtocol':
         contractClass = require('@daostack/arc/build/contracts/GenesisProtocol.json')
-        contract = new this.web3.eth.Contract(contractClass.abi, addresses.base.GenesisProtocol, opts)
+        contract = new this.web3.eth.Contract(contractClass.abi, addresses.GenesisProtocol, opts)
         return contract
       case 'Redeemer':
         contractClass = require('@daostack/arc/build/contracts/Redeemer.json')
-        contract = new this.web3.eth.Contract(contractClass.abi, addresses.base.Redeemer, opts)
+        contract = new this.web3.eth.Contract(contractClass.abi, addresses.Redeemer, opts)
         return contract
       case 'Reputation':
         contractClass = require('@daostack/arc/build/contracts/Reputation.json')
-        contract = new this.web3.eth.Contract(contractClass.abi, addresses.dao.Reputation, opts)
+        contract = new this.web3.eth.Contract(contractClass.abi, addresses.Reputation, opts)
         return contract
       default:
         throw Error(`Unknown contract: ${name}`)
@@ -343,7 +345,7 @@ export class Arc {
 
   public GENToken() {
     if (this.contractAddresses) {
-      return new Token(this.contractAddresses.base.GEN, this)
+      return new Token(this.contractAddresses.GEN, this)
     } else {
       throw Error(`Cannot get GEN Token because no contract addresses were provided`)
     }
@@ -431,9 +433,13 @@ export interface IApolloQueryOptions {
   fetchPolicy?: 'cache-first' | 'cache-and-network' | 'network-only' | 'cache-only' | 'no-cache' | 'standby'
 }
 
-export interface IContractAddresses {
+export interface IContractAddressesFromMigration {
   base: { [key: string]: Address }
   dao: { [key: string]: Address }
   organs: { [key: string]: Address }
   test: { [key: string]: Address }
+}
+
+export interface IContractAddresses {
+  [key: string]: Address
 }

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -343,10 +343,10 @@ export class Arc {
         contractClass = require('@daostack/arc/build/contracts/Redeemer.json')
         contract = new this.web3.eth.Contract(contractClass.abi, addresses.Redeemer, opts)
         return contract
-      case 'Reputation':
-        contractClass = require('@daostack/arc/build/contracts/Reputation.json')
-        contract = new this.web3.eth.Contract(contractClass.abi, addresses.Reputation, opts)
-        return contract
+      // case 'Reputation':
+      //   contractClass = require('@daostack/arc/build/contracts/Reputation.json')
+      //   contract = new this.web3.eth.Contract(contractClass.abi, addresses.Reputation, opts)
+      //   return contract
       default:
         throw Error(`Unknown contract: ${name}`)
     }

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -432,13 +432,6 @@ export interface IApolloQueryOptions {
   fetchPolicy?: 'cache-first' | 'cache-and-network' | 'network-only' | 'cache-only' | 'no-cache' | 'standby'
 }
 
-export interface IContractAddressesFromMigration {
-  base: { [key: string]: Address }
-  dao: { [key: string]: Address }
-  organs: { [key: string]: Address }
-  test: { [key: string]: Address }
-}
-
 export interface IContractAddresses {
   [key: string]: Address
 }

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -343,10 +343,6 @@ export class Arc {
         contractClass = require('@daostack/arc/build/contracts/Redeemer.json')
         contract = new this.web3.eth.Contract(contractClass.abi, addresses.Redeemer, opts)
         return contract
-      // case 'Reputation':
-      //   contractClass = require('@daostack/arc/build/contracts/Reputation.json')
-      //   contract = new this.web3.eth.Contract(contractClass.abi, addresses.Reputation, opts)
-      //   return contract
       default:
         throw Error(`Unknown contract: ${name}`)
     }

--- a/src/reputation.ts
+++ b/src/reputation.ts
@@ -75,7 +75,8 @@ export class Reputation implements IStateful<IReputationState> {
     const errHandler = async (err: Error) => {
       const owner = await contract.methods.owner().call()
       if (owner.toLowerCase() !== sender.toLowerCase()) {
-        return Error(`Minting failed: sender ${sender} is not the owner of the contract at ${contract._address} (which is ${owner})`)
+        return Error(`Minting failed: sender ${sender} is not the owner of the contract at ${contract._address}` +
+          `(which is ${owner})`)
       }
       return err
     }

--- a/src/reputation.ts
+++ b/src/reputation.ts
@@ -75,7 +75,7 @@ export class Reputation implements IStateful<IReputationState> {
     const errHandler = async (err: Error) => {
       const owner = await contract.methods.owner().call()
       if (owner.toLowerCase() !== sender.toLowerCase()) {
-        return Error(`Minting failed: sender ${sender} is not the owner of the contract (which is ${owner})`)
+        return Error(`Minting failed: sender ${sender} is not the owner of the contract at ${contract._address} (which is ${owner})`)
       }
       return err
     }

--- a/src/token.ts
+++ b/src/token.ts
@@ -140,8 +140,9 @@ export class Token implements IStateful<ITokenState> {
 
   public allowances(options: { owner?: Address, spender?: Address}): Observable<IAllowance[]> {
     // the allownaces entry tracks the GEN token, so the query only makes sense if the current token is the GEN token
-    if (this.address !== this.context.getContract('GEN').options.address) {
-      throw Error(`This token is not the GEN token - cannot query for allowances`)
+    if (this.address.toLowerCase() !== this.context.getContract('GEN').options.address.toLowerCase()) {
+      throw Error(`This token (@${this.address}) is not the GEN token` +
+         `(@${this.context.getContract('GEN').options.address})- cannot query for allowances`)
     }
 
     let whereclause = ''

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,17 +1,18 @@
 import { InMemoryCache } from 'apollo-cache-inmemory'
-import { ApolloClient } from 'apollo-client'
+import { ApolloClient, ApolloQueryResult } from 'apollo-client'
 import { split } from 'apollo-link'
 import { Observable as ZenObservable } from 'apollo-link'
 import { HttpLink } from 'apollo-link-http'
 import { WebSocketLink } from 'apollo-link-ws'
 import { getMainDefinition } from 'apollo-utilities'
 import BN = require('bn.js')
+import gql from 'graphql-tag'
 import fetch from 'isomorphic-fetch'
 import * as WebSocket from 'isomorphic-ws'
-import {  Observable, Observer } from 'rxjs'
+import { Observable, Observer } from 'rxjs'
+import { IContractAddresses } from './arc'
 import { Logger } from './logger'
 import { Address } from './types'
-
 const Web3 = require('web3')
 
 export function fromWei(amount: BN): string {
@@ -155,4 +156,63 @@ export function zenToRxjsObservable(zenObservable: ZenObservable<any>) {
     const subscription = zenObservable.subscribe(obs)
     return () => subscription.unsubscribe()
   })
+}
+
+/**
+ * get the contract addresses by querying the "meta-url" of the subgraph deployment
+ * (in the default configuration, if the subgraph is at a url of the form:
+ *      http://some.thing/subgraphs/name/{subgraphName}/graphql
+ * then the "metaurl" is:
+ *      http://some.thing/subgraphs/graphql
+ * @param  graphqlHttpProvider a URL of the form http://some.thing/subgraphs/graphql
+ * @param  subgraphName        name of the subgraph
+ * @return                     an array with contract names as keys and addresses as values
+ */
+export async function getContractAddresses(graphqlHttpProvider: string, subgraphName: string) {
+
+  const query = gql`{
+    subgraphs (where: { name: "${subgraphName}"} ) {
+      id
+      name
+      currentVersion {
+        deployment {
+          manifest {
+            dataSources {
+              name
+              source {
+                abi
+                address
+              }
+            }
+          }
+        }
+      }
+    }
+  }`
+  const httpLink = new HttpLink({
+    credentials: 'same-origin',
+    fetch,
+    uri: graphqlHttpProvider
+  })
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: httpLink
+  })
+
+  let response: any
+  try {
+    response = await client.query({query}) as ApolloQueryResult<{ subgraphs: any[]}>
+  } catch (err) {
+    console.log(err)
+    throw err
+  }
+  const dataSources = response.data.subgraphs[0].currentVersion.deployment.manifest.dataSources
+  const result: IContractAddresses = {}
+  for (const record of dataSources) {
+    const name: string = record.name
+    const address = record.source.address
+    result[name] = address.toLowerCase()
+  }
+  return result
 }

--- a/test/dao.spec.ts
+++ b/test/dao.spec.ts
@@ -2,7 +2,7 @@ import BN = require('bn.js')
 import { first } from 'rxjs/operators'
 import { Arc } from '../src/arc'
 import { DAO } from '../src/dao'
-import { fromWei, newArc, getTestDAO, toWei, waitUntilTrue } from './utils'
+import { fromWei, getTestDAO, newArc, toWei, waitUntilTrue } from './utils'
 
 /**
  * DAO test
@@ -11,7 +11,7 @@ describe('DAO', () => {
   let arc: Arc
 
   beforeAll(async () => {
-    arc = newArc()
+    arc = await newArc()
 })
 
   it('DAO is instantiable', () => {

--- a/test/member.spec.ts
+++ b/test/member.spec.ts
@@ -6,7 +6,8 @@ import { IProposalOutcome, Proposal } from '../src/proposal'
 import { Stake } from '../src/stake'
 import { Address } from '../src/types'
 import { Vote } from '../src/vote'
-import { createAProposal, fromWei, newArc, getContractAddresses, getTestDAO, toWei, waitUntilTrue } from './utils'
+import { createAProposal, fromWei, getContractAddressesFromMigration,
+  getTestDAO, newArc, toWei, waitUntilTrue } from './utils'
 
 jest.setTimeout(10000)
 
@@ -21,8 +22,8 @@ describe('Member', () => {
   let dao: DAO
 
   beforeAll(async () => {
-    addresses = getContractAddresses()
-    arc = newArc()
+    addresses = getContractAddressesFromMigration()
+    arc = await newArc()
     dao = await getTestDAO()
     defaultAccount = arc.web3.eth.defaultAccount
   })

--- a/test/member.spec.ts
+++ b/test/member.spec.ts
@@ -6,7 +6,8 @@ import { IProposalOutcome, Proposal } from '../src/proposal'
 import { Stake } from '../src/stake'
 import { Address } from '../src/types'
 import { Vote } from '../src/vote'
-import { createAProposal, fromWei, getContractAddresses, getTestDAO, newArc, toWei, waitUntilTrue } from './utils'
+import { createAProposal, fromWei, getContractAddressesFromMigration,
+  getTestDAO, IContractAddressesFromMigration, newArc, toWei, waitUntilTrue } from './utils'
 
 jest.setTimeout(10000)
 
@@ -15,7 +16,7 @@ jest.setTimeout(10000)
  */
 describe('Member', () => {
 
-  let addresses: IContractAddresses
+  let addresses: IContractAddressesFromMigration
   let arc: Arc
   let defaultAccount: Address
   let dao: DAO
@@ -39,7 +40,7 @@ describe('Member', () => {
     expect(Number(fromWei(memberState.tokens))).toBeGreaterThan(0)
     expect(memberState.dao).toBeInstanceOf(DAO)
     expect(memberState.address).toEqual(defaultAccount)
-    expect(memberState.dao.address).toBe(addresses.test.Avatar.toLowerCase())
+    expect(memberState.dao.address).toBe(dao.address.toLowerCase())
   })
 
   it('Member state also works for members that are not in the index', async () => {
@@ -88,14 +89,15 @@ describe('Member', () => {
       arc.web3.eth.defaultAccount = defaultAccount
     })
 
-  it.skip('Member votes() works', async () => {
+  it('Member votes() works', async () => {
     const member = new Member(defaultAccount, dao.address, arc)
     const proposal = await createAProposal()
-    await proposal.vote(IProposalOutcome.Pass).send()
-    let votes: Vote[] = []
-    member.votes().subscribe((next: Vote[]) => votes = next)
+    const votes: Vote[][] = []
+    member.votes().subscribe((next: Vote[]) => votes.push(next))
     await waitUntilTrue(() => votes.length > 0)
-    expect(votes.length).toBeGreaterThan(0)
-    expect(votes[0].proposalId).toEqual(proposal.id)
+    await proposal.vote(IProposalOutcome.Pass).send()
+    await waitUntilTrue(() => votes.length > 1)
+    expect(votes[votes.length - 1].length).toBeGreaterThan(0)
+    expect(votes[votes.length - 1].map((vote) => vote.proposalId)).toContain(proposal.id)
   })
 })

--- a/test/operation.spec.ts
+++ b/test/operation.spec.ts
@@ -1,6 +1,6 @@
-import { ITransactionUpdate, ITransactionState } from '../src/operation'
+import { ITransactionState, ITransactionUpdate } from '../src/operation'
 import { Proposal } from '../src/proposal'
-import { newArc, getTestDAO, mineANewBlock, toWei, waitUntilTrue } from './utils'
+import { getTestDAO, mineANewBlock, newArc, toWei, waitUntilTrue } from './utils'
 
 jest.setTimeout(10000)
 
@@ -11,10 +11,10 @@ describe('Operation', () => {
     const arc = await newArc()
     const options = {
       beneficiary: '0xffcf8fdee72ac11b5c542428b35eef5769c409f0',
-      ethReward: toWei("300"),
+      ethReward: toWei('300'),
       externalTokenAddress: undefined,
-      externalTokenReward: toWei("0"),
-      nativeTokenReward: toWei("1"),
+      externalTokenReward: toWei('0'),
+      nativeTokenReward: toWei('1'),
       periodLength: 12,
       periods: 5,
       type: 'ConributionReward'
@@ -63,5 +63,5 @@ describe('Operation', () => {
       transactionHash: listOfUpdates[1].transactionHash
     })
 
-  })
+  }, 20000)
 })

--- a/test/proposal-claim-reward.spec.ts
+++ b/test/proposal-claim-reward.spec.ts
@@ -1,13 +1,13 @@
 import BN = require('bn.js')
 import { Arc } from '../src/arc'
 import { Proposal } from '../src/proposal'
-import { createAProposal, newArc, getTestDAO, toWei } from './utils'
+import { createAProposal, getTestDAO, newArc, toWei } from './utils'
 
 describe('Claim rewards', () => {
   let arc: Arc
 
   beforeAll(async () => {
-    arc = newArc()
+    arc = await newArc()
   })
 
   it('works ', async () => {

--- a/test/proposal-create.spec.ts
+++ b/test/proposal-create.spec.ts
@@ -5,10 +5,10 @@ import { Logger } from '../src/logger'
 import { IProposalStage, Proposal } from '../src/proposal'
 import {
   fromWei,
-  newArc,
   getTestDAO,
   graphqlHttpProvider,
   graphqlWsProvider,
+  newArc,
   toWei,
   waitUntilTrue,
   web3Provider
@@ -22,7 +22,7 @@ describe('Create a ContributionReward proposal', () => {
   let accounts: any
 
   beforeAll(async () => {
-    arc = newArc()
+    arc = await newArc()
     web3 = arc.web3
     accounts = web3.eth.accounts.wallet
     web3.eth.defaultAccount = accounts[0].address

--- a/test/proposal-execute.spec.ts
+++ b/test/proposal-execute.spec.ts
@@ -2,7 +2,7 @@ import BN = require('bn.js')
 import { first } from 'rxjs/operators'
 import { Arc } from '../src/arc'
 import { IProposalOutcome, IProposalStage, IProposalState, Proposal } from '../src/proposal'
-import { createAProposal, fromWei, getContractAddresses, getTestDAO, mintSomeReputation, newArc, toWei, waitUntilTrue } from './utils'
+import { createAProposal, fromWei, getContractAddressesFromMigration, getTestDAO, mintSomeReputation, newArc, toWei, waitUntilTrue } from './utils'
 
 jest.setTimeout(10000)
 

--- a/test/proposal-stake.spec.ts
+++ b/test/proposal-stake.spec.ts
@@ -13,7 +13,7 @@ describe('Stake on a ContributionReward', () => {
   let accounts: any
 
   beforeAll(async () => {
-    arc = newArc()
+    arc = await newArc()
     web3 = arc.web3
     accounts = web3.eth.accounts.wallet
   })

--- a/test/proposal-vote.spec.ts
+++ b/test/proposal-vote.spec.ts
@@ -10,7 +10,7 @@ describe('Vote on a ContributionReward', () => {
   let dao: DAO
 
   beforeAll(async () => {
-    arc = newArc()
+    arc = await newArc()
     dao = await getTestDAO()
   })
 

--- a/test/proposal.spec.ts
+++ b/test/proposal.spec.ts
@@ -14,7 +14,7 @@ describe('Proposal', () => {
   let arc: Arc
 
   beforeAll(async () => {
-    arc = newArc()
+    arc = await newArc()
   })
 
   it('Proposal is instantiable', () => {

--- a/test/reputation.spec.ts
+++ b/test/reputation.spec.ts
@@ -3,7 +3,7 @@ import { first} from 'rxjs/operators'
 import { Arc } from '../src/arc'
 import { Reputation } from '../src/reputation'
 import { Address } from '../src/types'
-import { fromWei, getContractAddresses, newArc, toWei } from './utils'
+import { fromWei, getContractAddressesFromMigration, newArc, toWei } from './utils'
 /**
  * Reputation test
  */
@@ -15,9 +15,9 @@ describe('Reputation', () => {
   let accounts: any
 
   beforeAll(async () => {
-    addresses = getContractAddresses()
+    addresses = getContractAddressesFromMigration()
     address = addresses.dao.Reputation
-    arc = newArc()
+    arc = await newArc()
     accounts = arc.web3.eth.accounts.wallet
   })
 

--- a/test/reputation.spec.ts
+++ b/test/reputation.spec.ts
@@ -64,8 +64,8 @@ describe('Reputation', () => {
     const reputationAfter = new BN(await reputation.contract().methods.balanceOf(accounts[3].address).call())
     const difference = reputationAfter.sub(reputationBefore)
     expect(difference.toString()).toEqual('1000000000003003837')
-
   })
+
   it('mint() throws a meaningful error if the sender is not the contract owner', async () => {
     const reputation = new Reputation(addresses.test.Reputation, arc)
     await expect(reputation.mint(accounts[3].address, toWei(1)).send()).rejects.toThrow(

--- a/test/reward.spec.ts
+++ b/test/reward.spec.ts
@@ -2,7 +2,7 @@ import { first, take } from 'rxjs/operators'
 import { Arc } from '../src/arc'
 import { Proposal } from '../src/proposal'
 import { Reward } from '../src/reward'
-import { newArc, getTestDAO, toWei } from './utils'
+import { getTestDAO, newArc, toWei } from './utils'
 
 /**
  * Reward test
@@ -11,8 +11,8 @@ describe('Reward', () => {
 
   let arc: Arc
 
-  beforeAll(() => {
-    arc = newArc()
+  beforeAll(async () => {
+    arc = await newArc()
   })
 
   it('Reward is instantiable', () => {

--- a/test/stake.spec.ts
+++ b/test/stake.spec.ts
@@ -11,8 +11,8 @@ describe('Stake', () => {
 
   let arc: Arc
 
-  beforeAll(() => {
-    arc = newArc()
+  beforeAll(async () => {
+    arc = await newArc()
   })
 
   it('Stake is instantiable', () => {

--- a/test/token.spec.ts
+++ b/test/token.spec.ts
@@ -3,7 +3,7 @@ import { first} from 'rxjs/operators'
 import { Arc, IContractAddresses } from '../src/arc'
 import { Token } from '../src/token'
 import { Address } from '../src/types'
-import { fromWei, getContractAddresses, newArc, toWei, waitUntilTrue } from './utils'
+import { fromWei, getContractAddressesFromMigration, newArc, toWei, waitUntilTrue } from './utils'
 
 jest.setTimeout(10000)
 /**
@@ -15,8 +15,8 @@ describe('Token', () => {
   let address: Address
 
   beforeAll(async () => {
-    arc = newArc()
-    addresses = getContractAddresses()
+    arc = await newArc()
+    addresses = getContractAddressesFromMigration()
     address = addresses.dao.DAOToken
   })
 

--- a/test/token.spec.ts
+++ b/test/token.spec.ts
@@ -1,16 +1,17 @@
 import BN = require('bn.js')
 import { first} from 'rxjs/operators'
-import { Arc, IContractAddresses } from '../src/arc'
+import { Arc  } from '../src/arc'
 import { Token } from '../src/token'
 import { Address } from '../src/types'
-import { fromWei, getContractAddressesFromMigration, newArc, toWei, waitUntilTrue } from './utils'
+import { fromWei, getContractAddressesFromMigration, IContractAddressesFromMigration,
+   newArc, toWei, waitUntilTrue } from './utils'
 
 jest.setTimeout(10000)
 /**
  * Token test
  */
 describe('Token', () => {
-  let addresses: IContractAddresses
+  let addresses: IContractAddressesFromMigration
   let arc: Arc
   let address: Address
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -49,7 +49,6 @@ export interface IContractAddressesFromMigration {
 export function getContractAddressesFromMigration(): IContractAddressesFromMigration {
   const path = '@daostack/migration/migration.json'
   const addresses = require(path)
-  // const addresses = { base: require(path).private.base, dao: require(path).private.dao }
   if (!addresses || addresses === {}) {
     throw Error(`No addresses found, does the file at ${path} exist?`)
   }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,11 +1,9 @@
-import { ApolloQueryResult } from 'apollo-client'
 import BN = require('bn.js')
-import gql from 'graphql-tag'
-import { IContractAddresses } from '../src/arc'
 import { DAO } from '../src/dao'
 import Arc from '../src/index'
 import { Proposal } from '../src/proposal'
 import { Reputation } from '../src/reputation'
+import { Address } from '../src/types'
 import { getContractAddresses } from '../src/utils'
 const Web3 = require('web3')
 
@@ -41,7 +39,14 @@ export function toWei(amount: string | number): BN {
   return new BN(Web3.utils.toWei(amount.toString(), 'ether'))
 }
 
-export function getContractAddressesFromMigration(): IContractAddresses {
+export interface IContractAddressesFromMigration {
+  base: { [key: string]: Address }
+  dao: { [key: string]: Address }
+  organs: { [key: string]: Address }
+  test: { [key: string]: Address }
+}
+
+export function getContractAddressesFromMigration(): IContractAddressesFromMigration {
   const path = '@daostack/migration/migration.json'
   const addresses = require(path)
   // const addresses = { base: require(path).private.base, dao: require(path).private.dao }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,6 +4,7 @@ import Arc from '../src/index'
 import { Proposal } from '../src/proposal'
 import { Reputation } from '../src/reputation'
 import { Address } from '../src/types'
+import { getContractAddresses } from '../src/utils'
 const Web3 = require('web3')
 
 export const graphqlHttpProvider: string = 'http://127.0.0.1:8000/subgraphs/name/daostack'

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,7 +4,6 @@ import Arc from '../src/index'
 import { Proposal } from '../src/proposal'
 import { Reputation } from '../src/reputation'
 import { Address } from '../src/types'
-import { getContractAddresses } from '../src/utils'
 const Web3 = require('web3')
 
 export const graphqlHttpProvider: string = 'http://127.0.0.1:8000/subgraphs/name/daostack'

--- a/test/vote.spec.ts
+++ b/test/vote.spec.ts
@@ -2,7 +2,7 @@ import { first } from 'rxjs/operators'
 import { Arc } from '../src/arc'
 import { IProposalOutcome} from '../src/proposal'
 import { Vote } from '../src/vote'
-import { createAProposal, newArc, getTestDAO, toWei, waitUntilTrue } from './utils'
+import { createAProposal, getTestDAO, newArc, toWei, waitUntilTrue } from './utils'
 
 jest.setTimeout(10000)
 
@@ -13,8 +13,8 @@ describe('Stake', () => {
 
   let arc: Arc
 
-  beforeAll(() => {
-    arc = newArc()
+  beforeAll(async () => {
+    arc = await newArc()
   })
 
   it('Vote is instantiable', () => {


### PR DESCRIPTION
This is an attempt to get the contract addresses from the subgraph.

It works pretty well, excet that we need the addres of the Redeemer contract, which is not indexed, and therefore not available amount the indexed addresses.

For reference, try this query:

https://rinkeby.subgraph.daostack.io/subgraphs/graphql?query=%20%7B%0A%20%20%20%20%20%20%20%20%20%20subgraphs%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20%20%20%20%20currentVersion%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20deployment%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20manifest%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20dataSources%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20source%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20abi%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20address%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%0A