### PR TITLE
add docker to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "typings": "dist/types/index.d.ts",
   "files": [
     "dist",
-    "src"
+    "src",
+    "docker-compose.yml"
   ],
   "author": "Matan Tsuberi <tsuberim@gmail.com>, Jelle Gerbrandy <jelle@daostack.io>",
   "repository": {


### PR DESCRIPTION
I think that it's useful to have this added to the published package because it makes it easier for projects to integrate this library.

Simply add this package as a dependency, and stand up the test environment via `docker-compose -f ./node_modules/@daostack/client/docker-compose.yml up graph-node`.

Additionally if there are other containers needed for the environment, they can use the docker-compose extends functionality: https://docs.docker.com/compose/extends/ .

I view this as being a best practice because it minimizes code duplication and provides a single source of truth for dependents.