### PR TITLE
remove metamask handling in arc.constructor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/client",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/client",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "",
   "keywords": [],
   "main": "dist/lib/index.js",

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -53,19 +53,7 @@ export class Arc extends GraphNodeObserver {
     })
     this.ipfsProvider = options.ipfsProvider
 
-    let web3provider: any
-
-    // TODO: this is probably better to handle explicitly in the frontend
-    // check if we have a web3 provider set in the window object (in the browser)
-    // cf. https://metamask.github.io/metamask-docs/API_Reference/Ethereum_Provider
-    if (typeof window !== 'undefined' &&
-      (typeof (window as any).ethereum !== 'undefined' || typeof (window as any).web3 !== 'undefined')
-    ) {
-      // Web3 browser user detected. You can now use the provider.
-      web3provider = (window as any).ethereum || (window as any).web3.currentProvider
-    } else {
-      web3provider = Web3.givenProvider || options.web3Provider
-    }
+    const web3provider = options.web3Provider
 
     if (web3provider) {
       this.web3 = new Web3(web3provider)

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -5,6 +5,7 @@ import { Logger } from './logger'
 import { Web3Receipt } from './types'
 
 export enum ITransactionState {
+  Sending,
   Sent,
   Mined
 }
@@ -14,7 +15,7 @@ export enum ITransactionState {
  */
 export interface ITransactionUpdate<T> {
   state: ITransactionState
-  transactionHash: string
+  transactionHash?: string
   receipt?: object
   /**
    *  number of confirmations
@@ -74,9 +75,11 @@ export function sendTransaction<T>(
     const options = {
       from: await context.getAccount().pipe(first()).toPromise()
     }
-    const emitter = tx.send(options)
-
-    emitter
+    observer.next({
+      state: ITransactionState.Sending,
+      transactionHash: undefined
+    })
+    tx.send(options)
       .once('transactionHash', (hash: string) => {
         Logger.debug('Sending transaction..')
         transactionHash = hash

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -76,8 +76,7 @@ export function sendTransaction<T>(
       from: await context.getAccount().pipe(first()).toPromise()
     }
     observer.next({
-      state: ITransactionState.Sending,
-      transactionHash: undefined
+      state: ITransactionState.Sending
     })
     tx.send(options)
       .once('transactionHash', (hash: string) => {
@@ -135,6 +134,7 @@ export function sendTransaction<T>(
       })
     }
   )
-  observable.send = () => observable.pipe(take(2)).toPromise()
+  // the 3rd update we get from the observable is the confirmation that it is mined
+  observable.send = () => observable.pipe(take(3)).toPromise()
   return observable
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,13 +105,13 @@ export async function getOptionsFromChain(web3Instance: any) {
 }
 
 export function getWeb3Options(web3Instance: any) {
-  if (!web3Instance.eth.defaultAccount) {
+  const defaultAccount = web3Instance.eth.defaultAccount
+  if (!defaultAccount) {
     const msg = `No defaultAccount was set -- cannot send transaction`
     Logger.warn(msg)
-    throw Error(msg)
   }
   return {
-    from: web3Instance.eth.defaultAccount,
+    from: defaultAccount,
     gas: 6000000
   }
 }

--- a/test/operation.spec.ts
+++ b/test/operation.spec.ts
@@ -34,10 +34,10 @@ describe('Operation', () => {
     for (let i = 0; i < 4; i++) {
       await mineANewBlock()
     }
-    // wait forl all pdates
+    // wait forl all updates
     await waitUntilTrue(() => listOfUpdates.length > 4)
 
-    // the first returned value is expected to be the "sent" (i.e. not mined yet)
+    // the first returned value is expected to be the "sending" (i.e. not mined yet)
     expect(listOfUpdates[0]).toMatchObject({
       state: ITransactionState.Sending
     })

--- a/test/operation.spec.ts
+++ b/test/operation.spec.ts
@@ -24,40 +24,45 @@ describe('Operation', () => {
     )
 
     // wait for the transaction to be mined
-    // (we expect first a 'transaction sent' update, then the 0 confirmation)
-    await waitUntilTrue(() => listOfUpdates.length === 2)
+    // (we expect first a
+    // 1 'transaction sending' update
+    // 2 'transaction sent' update,
+    // 3. then the 0 confirmation)
+    await waitUntilTrue(() => listOfUpdates.length === 3)
 
     // wait for all blocks mined in the reduce step
     for (let i = 0; i < 4; i++) {
       await mineANewBlock()
     }
     // wait forl all pdates
-    await waitUntilTrue(() => listOfUpdates.length > 3)
+    await waitUntilTrue(() => listOfUpdates.length > 4)
 
     // the first returned value is expected to be the "sent" (i.e. not mined yet)
     expect(listOfUpdates[0]).toMatchObject({
-      state: ITransactionState.Sent
+      state: ITransactionState.Sending
     })
     expect(listOfUpdates[1]).toMatchObject({
+      state: ITransactionState.Sent
+    })
+    expect(listOfUpdates[2]).toMatchObject({
       confirmations: 0,
       state: ITransactionState.Mined
     })
-    expect(listOfUpdates[1].result).toBeDefined()
-    expect(listOfUpdates[1].receipt).toBeDefined()
-    expect(listOfUpdates[1].transactionHash).toBeDefined()
+    expect(listOfUpdates[2].result).toBeDefined()
+    expect(listOfUpdates[2].receipt).toBeDefined()
+    expect(listOfUpdates[2].transactionHash).toBeDefined()
 
-    expect( listOfUpdates[1].result ).toBeInstanceOf(Proposal)
+    expect( listOfUpdates[2].result ).toBeInstanceOf(Proposal)
 
-    expect(listOfUpdates[2]).toMatchObject({
+    expect(listOfUpdates[3]).toMatchObject({
       confirmations: 1,
       state: ITransactionState.Mined
     })
-    expect(listOfUpdates[3]).toMatchObject({
+    expect(listOfUpdates[4]).toMatchObject({
       confirmations: 2,
-      receipt: listOfUpdates[1].receipt,
-      // result: listOfUpdates[1].result,
+      receipt: listOfUpdates[2].receipt,
       state: ITransactionState.Mined,
-      transactionHash: listOfUpdates[1].transactionHash
+      transactionHash: listOfUpdates[2].transactionHash
     })
 
   }, 20000)


### PR DESCRIPTION
this PR addresses 3 different issues:
- remove metamask handling from the library (this should be done browser-side)
- add an extra state to the transaction.send() function `Sending`, which returns immediatly (without waiting for metamask to open), to fix https://github.com/daostack/alchemy/issues/512
- do not throw an error when getting options, which shoudl solve our top sentry issue: https://sentry.io/organizations/daostack-technologies/issues/1017580779/?environment=production&project=1419793&query=is%3Aunresolved
- bump version number



- 