### PR TITLE
Fix

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,8 +9,7 @@ import gql from 'graphql-tag'
 import fetch from 'isomorphic-fetch'
 import * as WebSocket from 'isomorphic-ws'
 import { Observable, Observer } from 'rxjs'
-import { IContractInfo } from '../src/arc'
-import { IContractAddresses } from './arc'
+import { IContractAddresses, IContractInfo } from './arc'
 import { Address } from './types'
 const Web3 = require('web3')
 


### PR DESCRIPTION
When importing the @daostack/client npm package, this import causes an error because there is no "src" folder.