### PR TITLE
Generic scheme info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/client",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/client",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "",
   "keywords": [],
   "main": "dist/lib/index.js",

--- a/src/scheme.ts
+++ b/src/scheme.ts
@@ -19,6 +19,7 @@ export interface ISchemeState {
   canManageGlobalConstraints: boolean
   dao: Address
   paramsHash: string
+  genericScheme?: GenericScheme.IGenericSchemeInfo
 }
 
 export interface ISchemeQueryOptions extends ICommonQueryOptions {
@@ -133,6 +134,11 @@ export class Scheme {
           canUpgradeController
           canManageGlobalConstraints
           paramsHash
+          genericSchemeParams {
+            id
+            contractToCall
+            votingMachine
+          }
         }
       }
     `
@@ -140,6 +146,16 @@ export class Scheme {
     const itemMap = (item: any): ISchemeState|null => {
 
       const name = item.name || this.context.getContractInfo(item.address).name
+      let genericScheme: GenericScheme.IGenericSchemeInfo|undefined
+      if (item.genericSchemeParams) {
+        genericScheme = {
+          contractToCall: item.genericSchemeParams.contractToCall,
+          id: item.genericSchemeParams.id,
+          votingMachine: item.genericSchemeParams.votingMachine
+        }
+      } else {
+        genericScheme = undefined
+      }
       return {
         address: item.address,
         canDelegateCall: item.canDelegateCall,
@@ -147,6 +163,7 @@ export class Scheme {
         canRegisterSchemes: item.canRegisterSchemes,
         canUpgradeController: item.canUpgradeController,
         dao: item.dao.id,
+        genericScheme,
         id: item.id,
         name,
         paramsHash: item.paramsHash
@@ -161,7 +178,7 @@ export class Scheme {
      * @param  options [description ]
      * @return a Proposal instance
      */
-    public createProposal(options: IProposalCreateOptions): Operation<Proposal>  {
+    public createProposal(options: IProposalCreateOptions): Operation < Proposal >  {
       let msg: string
       const context = this.context
       let createTransaction: () => any = () => null
@@ -170,31 +187,31 @@ export class Scheme {
       switch (this.name) {
       // ContributionReward
         case 'ContributionReward':
-          createTransaction  = ContributionReward.createTransaction(options, this.context)
-          map = ContributionReward.createTransactionMap(options, this.context)
-          break
+             createTransaction  = ContributionReward.createTransaction(options, this.context)
+             map = ContributionReward.createTransactionMap(options, this.context)
+             break
 
         // GenericScheme
         case 'GenericScheme':
-          createTransaction  = GenericScheme.createTransaction(options, this.context)
-          map = GenericScheme.createTransactionMap(options, this.context)
-          break
+             createTransaction  = GenericScheme.createTransaction(options, this.context)
+             map = GenericScheme.createTransactionMap(options, this.context)
+             break
 
         // SchemeRegistrar
         case 'SchemeRegistrar':
-          createTransaction  = SchemeRegistrar.createTransaction(options, this.context)
-          map = SchemeRegistrar.createTransactionMap(options, this.context)
-          break
+             createTransaction  = SchemeRegistrar.createTransaction(options, this.context)
+             map = SchemeRegistrar.createTransactionMap(options, this.context)
+             break
 
         default:
-          msg = `Unknown proposal scheme: "${this.name}"`
-          throw Error(msg)
+             msg = `Unknown proposal scheme: "${this.name}"`
+             throw Error(msg)
       }
 
       return context.sendTransaction(createTransaction, map)
     }
 
-    public proposals(options: IProposalQueryOptions = {}): Observable<Proposal[]> {
+    public proposals(options: IProposalQueryOptions = {}): Observable < Proposal[] > {
       if (!options.where) { options.where = {}}
       options.where.scheme = this.address
       return Proposal.search(this.context, options)

--- a/src/schemes/genericScheme.ts
+++ b/src/schemes/genericScheme.ts
@@ -2,6 +2,12 @@ import { Arc } from '../arc'
 import { Proposal } from '../proposal'
 import { Address } from '../types'
 
+export interface IGenericSchemeInfo {
+  id: string
+  contractToCall: Address
+  votingMachine: Address
+}
+
 export interface IGenericScheme {
   id: string
   contractToCall: Address

--- a/test/scheme.spec.ts
+++ b/test/scheme.spec.ts
@@ -71,7 +71,8 @@ describe('Scheme', () => {
     })
 
   })
-  it.only('Scheme.state() is working for GenericScheme schemes', async () => {
+
+  it('Scheme.state() is working for GenericScheme schemes', async () => {
     const dao = await getTestDAO()
     const result = await Scheme
       .search(arc, {where: {dao: dao.address, name: 'GenericScheme'}})

--- a/test/scheme.spec.ts
+++ b/test/scheme.spec.ts
@@ -56,7 +56,7 @@ describe('Scheme', () => {
     expect(result.length).toEqual(1)
   })
 
-  it('Scheme.state() is working', async () => {
+  it('Scheme.state() is working for SchemeRegistrar schemes', async () => {
     const dao = await getTestDAO()
     const result = await Scheme
       .search(arc, {where: {dao: dao.address, name: 'SchemeRegistrar'}})
@@ -68,6 +68,26 @@ describe('Scheme', () => {
       address: testAddresses.base.SchemeRegistrar.toLowerCase(),
       id: scheme.id,
       name: 'SchemeRegistrar'
+    })
+
+  })
+  it.only('Scheme.state() is working for GenericScheme schemes', async () => {
+    const dao = await getTestDAO()
+    const result = await Scheme
+      .search(arc, {where: {dao: dao.address, name: 'GenericScheme'}})
+      .pipe(first()).toPromise()
+
+    const scheme = result[0]
+    const state = await scheme.state().pipe(first()).toPromise()
+    expect(state).toMatchObject({
+      address: testAddresses.base.GenericScheme.toLowerCase(),
+      genericScheme: {
+        contractToCall: '0xb113d904f84950c7b1c8663fab9baa1d8095b1e2',
+         id: '0x7f2d89a2453a5b49a6d98b0604d7a79892fe80f0f1d3d750710089edb1bbc583',
+         votingMachine: '0xaffd1e5d27968889e25ba045c53ed608ce5ee223'
+      },
+      id: scheme.id,
+      name: 'GenericScheme'
     })
 
   })


### PR DESCRIPTION
A quick hack to fix an issue in alchemy: adding generiscScheme information to the scheme.state().

